### PR TITLE
Added Scoop installation method for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ OS these should be easy to obtain. One can then install Pyzo with
 
 We also provide [binaries](https://github.com/pyzo/pyzo/releases) for Windows, Linux and MacOS.
 
+The Windows binary can also be installed and upgraded with [Scoop](https://scoop.sh):
+
+    scoop install pyzo
+    scoop upgrade pyzo
 
 ### License
 


### PR DESCRIPTION
Scoop install is a new option, available since 2021-12-12, https://github.com/ScoopInstaller/Extras/pull/6786. 
Adding note about it to Readme is just a suggestion.